### PR TITLE
remove word table cache

### DIFF
--- a/mllib/pom.xml
+++ b/mllib/pom.xml
@@ -51,6 +51,11 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-graphx_${scala.binary.version}</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-server</artifactId>
     </dependency>

--- a/mllib/src/main/scala/org/apache/spark/mllib/clustering/LDA.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/clustering/LDA.scala
@@ -697,10 +697,13 @@ private class DBHPartitioner(partitions: Int) extends Partitioner {
 
   def getPartition(key: Any): Int = {
     val edge = key.asInstanceOf[EdgeTriplet[Int, ED]]
-    val idx = math.min(edge.srcAttr, edge.dstAttr)
-    getPartition(idx)
+    val srcDeg = edge.srcAttr
+    val dstDeg = edge.dstAttr
+    val srcId = edge.srcId
+    val dstId = edge.dstId
+    val minId = if (srcDeg < dstDeg) srcId else dstId
+    getPartition(minId)
   }
-
   def getPartition(idx: Int): PartitionID = {
     (math.abs(idx * mixingPrime) % partitions).toInt
   }

--- a/mllib/src/main/scala/org/apache/spark/mllib/clustering/LDA.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/clustering/LDA.scala
@@ -340,7 +340,8 @@ object LDA {
       ctx.sendToDst(vector)
       ctx.sendToSrc(vector)
     }, _ + _, TripletFields.EdgeOnly).mapValues(t => {
-      t.compact(); t
+      t.compact()
+      t
     })
     graph.joinVertices(newCounter)((_, _, nc) => nc)
   }
@@ -369,7 +370,7 @@ object LDA {
     })
     edges.persist(storageLevel)
     var corpus: Graph[VD, ED] = Graph.fromEdges(edges, null, storageLevel, storageLevel)
-    corpus = corpus.partitionBy(PartitionStrategy.EdgePartition1D)
+    corpus = corpus.partitionBy(PartitionStrategy.EdgePartition2D)
     corpus = updateCounter(corpus, numTopics).cache()
     corpus.vertices.count()
     corpus.edges.count()

--- a/mllib/src/main/scala/org/apache/spark/mllib/clustering/LDA.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/clustering/LDA.scala
@@ -366,9 +366,9 @@ object LDA {
       }
     })
     var corpus: Graph[VD, ED] = Graph.fromEdges(edges, null, storageLevel, storageLevel)
+    corpus = corpus.partitionBy(PartitionStrategy.EdgePartition1D)
     corpus = updateCounter(corpus, numTopics).cache()
     corpus.vertices.count()
-    // corpus.partitionBy(PartitionStrategy.EdgePartition1D)
     corpus
   }
 

--- a/mllib/src/main/scala/org/apache/spark/mllib/clustering/LDA.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/clustering/LDA.scala
@@ -704,7 +704,12 @@ private class DBHPartitioner(partitions: Int) extends Partitioner {
     val minId = if (srcDeg < dstDeg) srcId else dstId
     getPartition(minId)
   }
+
   def getPartition(idx: Int): PartitionID = {
+    (math.abs(idx * mixingPrime) % partitions).toInt
+  }
+
+  def getPartition(idx: Long): PartitionID = {
     (math.abs(idx * mixingPrime) % partitions).toInt
   }
 

--- a/mllib/src/main/scala/org/apache/spark/mllib/clustering/LDA.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/clustering/LDA.scala
@@ -1,0 +1,621 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.mllib.clustering
+
+import java.lang.ref.SoftReference
+import java.util.Random
+
+import breeze.collection.mutable.OpenAddressHashArray
+import breeze.linalg.{DenseVector => BDV, HashVector => BHV,
+SparseVector => BSV, sum => brzSum}
+
+import org.apache.spark.broadcast.Broadcast
+import org.apache.spark.graphx._
+import org.apache.spark.Logging
+import org.apache.spark.mllib.linalg.distributed.{MatrixEntry, RowMatrix}
+import org.apache.spark.mllib.linalg.{DenseVector => SDV, SparseVector => SSV, Vector => SV}
+import org.apache.spark.rdd.RDD
+import org.apache.spark.serializer.KryoRegistrator
+import org.apache.spark.storage.StorageLevel
+import org.apache.spark.SparkContext._
+import org.apache.spark.util.collection.AppendOnlyMap
+import org.apache.spark.util.random.XORShiftRandom
+import org.apache.spark.util.Utils
+
+import LDA._
+import LDAUtils._
+
+class LDA private[mllib](
+  @transient var corpus: Graph[VD, ED],
+  val numTopics: Int,
+  val numTerms: Int,
+  val alpha: Double,
+  val beta: Double,
+  val alphaAS: Double,
+  @transient val storageLevel: StorageLevel)
+  extends Serializable with Logging {
+
+  def this(docs: RDD[(DocId, SSV)],
+    numTopics: Int,
+    alpha: Double,
+    beta: Double,
+    alphaAS: Double,
+    storageLevel: StorageLevel = StorageLevel.MEMORY_AND_DISK,
+    computedModel: Broadcast[LDAModel] = null) {
+    this(initializeCorpus(docs, numTopics, storageLevel, computedModel),
+      numTopics, docs.first()._2.size, alpha, beta, alphaAS, storageLevel)
+  }
+
+  // scalastyle:off
+  /**
+   * 语料库文档数
+   */
+  val numDocs = docVertices.count()
+
+  /**
+   * 语料库总的词数(包含重复)
+   */
+  val numTokens = corpus.edges.map(e => e.attr.size.toDouble).sum().toLong
+  // scalastyle:on
+
+  @transient private val sc = corpus.vertices.context
+  @transient private val seed = new Random().nextInt()
+  @transient private var innerIter = 1
+  @transient private var totalTopicCounter: BDV[Count] = collectTotalTopicCounter(corpus)
+
+  private def termVertices = corpus.vertices.filter(t => t._1 >= 0)
+
+  private def docVertices = corpus.vertices.filter(t => t._1 < 0)
+
+  private def checkpoint(): Unit = {
+    if (innerIter % 10 == 0 && sc.getCheckpointDir.isDefined) {
+      val edges = corpus.edges.map(t => t)
+      edges.checkpoint()
+      val newCorpus: Graph[VD, ED] = Graph.fromEdges(edges, null,
+        storageLevel, storageLevel)
+      corpus = updateCounter(newCorpus, numTopics).persist(storageLevel)
+    }
+  }
+
+  private def collectTotalTopicCounter(graph: Graph[VD, ED]): BDV[Count] = {
+    val globalTopicCounter = collectGlobalCounter(graph, numTopics)
+    assert(brzSum(globalTopicCounter) == numTokens)
+    globalTopicCounter
+  }
+
+  private def gibbsSampling(): Unit = {
+    val sampledCorpus = sampleTokens(corpus, totalTopicCounter, innerIter + seed,
+      numTokens, numTopics, numTerms, alpha, alphaAS, beta)
+    sampledCorpus.persist(storageLevel)
+
+    val counterCorpus = updateCounter(sampledCorpus, numTopics)
+    counterCorpus.persist(storageLevel)
+    counterCorpus.vertices.count()
+    counterCorpus.edges.count()
+    totalTopicCounter = collectTotalTopicCounter(counterCorpus)
+
+    corpus.edges.unpersist(false)
+    corpus.vertices.unpersist(false)
+    sampledCorpus.edges.unpersist(false)
+    sampledCorpus.vertices.unpersist(false)
+    corpus = counterCorpus
+
+    checkpoint()
+    innerIter += 1
+  }
+
+  def saveModel(burnInIter: Int): LDAModel = {
+    var termTopicCounter: RDD[(VertexId, VD)] = null
+    for (iter <- 1 to burnInIter) {
+      logInfo(s"Save TopicModel (Iteration $iter/$burnInIter)")
+      var previousTermTopicCounter = termTopicCounter
+      gibbsSampling()
+      val newTermTopicCounter = termVertices
+      termTopicCounter = Option(termTopicCounter).map(_.join(newTermTopicCounter).map {
+        case (term, (a, b)) =>
+          val c = new BHV(a) + new BHV(b)
+          (term, c.array)
+      }).getOrElse(newTermTopicCounter)
+
+      termTopicCounter.cache().count()
+      Option(previousTermTopicCounter).foreach(_.unpersist())
+      previousTermTopicCounter = termTopicCounter
+    }
+    val model = LDAModel(numTopics, numTerms, alpha, beta)
+    termTopicCounter.collect().foreach { case (term, counter) =>
+      model.merge(term.toInt, new BHV(counter))
+    }
+    model.gtc :/= burnInIter.toDouble
+    model.ttc.foreach { ttc =>
+      ttc :/= burnInIter.toDouble
+      ttc.compact()
+    }
+    model
+  }
+
+  def runGibbsSampling(iterations: Int): Unit = {
+    for (iter <- 1 to iterations) {
+      println(s"perplexity $iter: ${perplexity()}")
+      logInfo(s"Start Gibbs sampling (Iteration $iter/$iterations)")
+      gibbsSampling()
+    }
+  }
+
+  def mergeDuplicateTopic(threshold: Double = 0.95D): Map[Int, Int] = {
+    val rows = termVertices.map(t => t._2).map { bsv =>
+      val length = bsv.length
+      val used = bsv.activeSize
+      val index = bsv.index.slice(0, used)
+      val data = bsv.data.slice(0, used).map(_.toDouble)
+      new SSV(length, index, data).asInstanceOf[SV]
+    }
+    val simMatrix = new RowMatrix(rows).columnSimilarities()
+    val minMap = simMatrix.entries.filter { case MatrixEntry(row, column, sim) =>
+      sim > threshold && row != column
+    }.map { case MatrixEntry(row, column, sim) =>
+      (column.toInt, row.toInt)
+    }.groupByKey().map { case (topic, simTopics) =>
+      (topic, simTopics.min)
+    }.collect().toMap
+    if (minMap.size > 0) {
+      corpus = corpus.mapEdges(edges => {
+        edges.attr.map { topic =>
+          minMap.get(topic).getOrElse(topic)
+        }
+      })
+      corpus = updateCounter(corpus, numTopics)
+    }
+    minMap
+  }
+
+
+  // scalastyle:off
+  /**
+   * 词在所有主题分布和该词所在文本的主题分布乘积: p(w)=\sum_{k}{p(k|d)*p(w|k)}=
+   * \sum_{k}{\frac{{n}_{kw}+{\beta }_{w}} {{n}_{k}+\bar{\beta }} \frac{{n}_{kd}+{\alpha }_{k}} {\sum{{n}_{k}}+\bar{\alpha }}}=
+   * \sum_{k} \frac{{\alpha }_{k}{\beta }_{w}  + {n}_{kw}{\alpha }_{k} + {n}_{kd}{\beta }_{w} + {n}_{kw}{n}_{kd}}{{n}_{k}+\bar{\beta }} \frac{1}{\sum{{n}_{k}}+\bar{\alpha }}}
+   * \exp^{-(\sum{\log(p(w))})/N}
+   * N为语料库包含的token数
+   */
+  // scalastyle:on
+  def perplexity(): Double = {
+    val totalTopicCounter = this.totalTopicCounter
+    val numTopics = this.numTopics
+    val numTerms = this.numTerms
+    val alpha = this.alpha
+    val beta = this.beta
+    val totalSize = brzSum(totalTopicCounter)
+    var totalProb = 0D
+
+    // \frac{{\alpha }_{k}{\beta }_{w}}{{n}_{k}+\bar{\beta }}
+    totalTopicCounter.activeIterator.foreach { case (topic, cn) =>
+      totalProb += alpha * beta / (cn + numTerms * beta)
+    }
+
+    val termProb = corpus.mapVertices { (vid, counter) =>
+      val probDist = BSV.zeros[Double](numTopics)
+      if (vid >= 0) {
+        val termTopicCounter = new BHV(counter)
+        // \frac{{n}_{kw}{\alpha }_{k}}{{n}_{k}+\bar{\beta }}
+        termTopicCounter.activeIterator.foreach { case (topic, cn) =>
+          probDist(topic) = cn * alpha /
+            (totalTopicCounter(topic) + numTerms * beta)
+        }
+      } else {
+        val docTopicCounter = new BHV(counter)
+        // \frac{{n}_{kd}{\beta }_{w}}{{n}_{k}+\bar{\beta }}
+        docTopicCounter.activeIterator.foreach { case (topic, cn) =>
+          probDist(topic) = cn * beta /
+            (totalTopicCounter(topic) + numTerms * beta)
+        }
+      }
+      probDist.compact()
+      (counter, probDist)
+    }.mapTriplets { triplet =>
+      val (termTopicCounter, termProb) = triplet.srcAttr
+      val (docTopicCounter, docProb) = triplet.dstAttr
+      val docSize = brzSum(new BHV(docTopicCounter))
+      val docTermSize = triplet.attr.length
+      var prob = 0D
+
+      // \frac{{n}_{kw}{n}_{kd}}{{n}_{k}+\bar{\beta}}
+      docTopicCounter.activeIterator.foreach { case (topic, cn) =>
+        prob += cn * termTopicCounter(topic) /
+          (totalTopicCounter(topic) + numTerms * beta)
+      }
+      prob += brzSum(docProb) + brzSum(termProb) + totalProb
+      prob += prob / (docSize + numTopics * alpha)
+
+      docTermSize * Math.log(prob)
+    }.edges.map(t => t.attr).sum()
+
+    math.exp(-1 * termProb / totalSize)
+  }
+}
+
+object LDA {
+
+  private[mllib] type DocId = VertexId
+  private[mllib] type WordId = VertexId
+  private[mllib] type Count = Int
+  private[mllib] type ED = Array[Count]
+  private[mllib] type VD = OpenAddressHashArray[Int]
+
+  def train(docs: RDD[(DocId, SSV)],
+    numTopics: Int = 2048,
+    totalIter: Int = 150,
+    burnIn: Int = 5,
+    alpha: Double = 0.1,
+    beta: Double = 0.01,
+    alphaAS: Double = 0.1): LDAModel = {
+    require(totalIter > burnIn, "totalIter is less than burnIn")
+    require(totalIter > 0, "totalIter is less than 0")
+    require(burnIn > 0, "burnIn is less than 0")
+    val topicModeling = new LDA(docs, numTopics, alpha, beta, alphaAS)
+    topicModeling.runGibbsSampling(totalIter - burnIn)
+    topicModeling.saveModel(burnIn)
+  }
+
+  def incrementalTrain(docs: RDD[(DocId, SSV)],
+    computedModel: LDAModel,
+    alphaAS: Double = 1,
+    totalIter: Int = 150,
+    burnIn: Int = 5): LDAModel = {
+    require(totalIter > burnIn, "totalIter is less than burnIn")
+    require(totalIter > 0, "totalIter is less than 0")
+    require(burnIn > 0, "burnIn is less than 0")
+    val numTopics = computedModel.ttc.size
+    val alpha = computedModel.alpha
+    val beta = computedModel.beta
+
+    val broadcastModel = docs.context.broadcast(computedModel)
+    val topicModeling = new LDA(docs, numTopics, alpha, beta, alphaAS,
+      computedModel = broadcastModel)
+    broadcastModel.unpersist()
+    topicModeling.runGibbsSampling(totalIter - burnIn)
+    topicModeling.saveModel(burnIn)
+  }
+
+  private[mllib] def sampleTokens(
+    graph: Graph[VD, ED],
+    totalTopicCounter: BDV[Count],
+    innerIter: Long,
+    numTokens: Double,
+    numTopics: Double,
+    numTerms: Double,
+    alpha: Double,
+    alphaAS: Double,
+    beta: Double): Graph[VD, ED] = {
+    val parts = graph.edges.partitions.size
+    val nweGraph = graph.mapTriplets(
+      (pid, iter) => {
+        val gen = new XORShiftRandom(parts * innerIter + pid)
+        val wordTableCache = new AppendOnlyMap[VertexId, SoftReference[(Double, Table)]]()
+        var t: Table = null
+        var tSum: Double = 0.0
+
+        iter.map {
+          triplet =>
+            val termId = triplet.srcId
+            val docId = triplet.dstId
+            val termTopicCounter = triplet.srcAttr
+            val docTopicCounter = triplet.dstAttr
+            val topics = triplet.attr
+            for (i <- 0 until topics.length) {
+              val currentTopic = topics(i)
+              if (t == null || gen.nextDouble() < 1e-6) {
+                val dv = tDense(totalTopicCounter, numTokens, numTerms, alpha, alphaAS, beta)
+                t = generateAlias(dv._2, dv._1)
+                tSum = dv._1
+              }
+
+              val (dSum, d) = docTopicCounter.synchronized {
+                termTopicCounter.synchronized {
+                  docTable(totalTopicCounter, termTopicCounter, docTopicCounter,
+                    currentTopic, numTokens, numTerms, alpha, alphaAS, beta)
+                }
+              }
+              val (wSum, w) = termTopicCounter.synchronized {
+                wordTable(gen, wordTableCache, totalTopicCounter,
+                  termTopicCounter, termId, numTokens, numTerms, alpha, alphaAS, beta)
+              }
+              val newTopic = docTopicCounter.synchronized {
+                termTopicCounter.synchronized {
+                  tokenSampling(gen, t, tSum, w, wSum, d, dSum)
+                }
+              }
+
+              if (newTopic != currentTopic) {
+                docTopicCounter.synchronized {
+                  docTopicCounter(currentTopic) -= 1
+                  docTopicCounter(newTopic) += 1
+                }
+                termTopicCounter.synchronized {
+                  termTopicCounter(currentTopic) -= 1
+                  termTopicCounter(newTopic) += 1
+                }
+
+                totalTopicCounter(currentTopic) -= 1
+                totalTopicCounter(newTopic) += 1
+
+                topics(i) = newTopic
+              }
+
+            }
+
+            topics
+        }
+      }, TripletFields.All)
+    nweGraph
+  }
+
+  private def updateCounter(graph: Graph[VD, ED], numTopics: Int): Graph[VD, ED] = {
+    val newCounter = graph.aggregateMessages[BSV[Count]](ctx => {
+      val topics = ctx.attr
+      val vector = BSV.zeros[Count](numTopics)
+      for (topic <- topics) {
+        vector(topic) += 1
+      }
+      ctx.sendToDst(vector)
+      ctx.sendToSrc(vector)
+    }, _ + _, TripletFields.EdgeOnly).mapValues { a =>
+      val b = new VD(a.length)
+      a.activeIterator.foreach { t =>
+        b(t._1) = t._2
+      }
+      b
+    }
+    graph.joinVertices(newCounter)((_, _, nc) => nc)
+  }
+
+  private def collectGlobalCounter(graph: Graph[VD, ED], numTopics: Int): BDV[Count] = {
+    graph.vertices.filter(t => t._1 >= 0).map(_._2).
+      aggregate(BDV.zeros[Count](numTopics))((a, b) => {
+      a :+= new BHV(b)
+    }, _ :+= _)
+  }
+
+  private def initializeCorpus(
+    docs: RDD[(LDA.DocId, SSV)],
+    numTopics: Int,
+    storageLevel: StorageLevel,
+    computedModel: Broadcast[LDAModel] = null): Graph[VD, ED] = {
+    val edges = docs.mapPartitionsWithIndex((pid, iter) => {
+      val gen = new Random(pid)
+      var model: LDAModel = null
+      if (computedModel != null) model = computedModel.value
+      iter.flatMap {
+        case (docId, doc) =>
+          initializeEdges(gen, new BSV[Int](doc.indices, doc.values.map(_.toInt), doc.size),
+            docId, numTopics, model)
+      }
+    })
+    var corpus: Graph[VD, ED] = Graph.fromEdges(edges, null, storageLevel, storageLevel)
+    corpus.partitionBy(PartitionStrategy.EdgePartition1D)
+    corpus = updateCounter(corpus, numTopics).cache()
+    corpus.vertices.count()
+    corpus
+  }
+
+  private def initializeEdges(
+    gen: Random,
+    doc: BSV[Int],
+    docId: DocId,
+    numTopics: Int,
+    computedModel: LDAModel = null): Array[Edge[ED]] = {
+    assert(docId >= 0)
+    val newDocId: DocId = -(docId + 1L)
+    if (computedModel == null) {
+      doc.activeIterator.map { case (termId, counter) =>
+        val ev = (0 until counter).map { i =>
+          gen.nextInt(numTopics)
+        }.toArray
+        Edge(termId, newDocId, ev)
+      }.toArray
+    }
+    else {
+      computedModel.setSeed(gen.nextInt())
+      val tokens = computedModel.vector2Array(doc)
+      val topics = new Array[Int](tokens.length)
+      var docTopicCounter = computedModel.uniformDistSampler(tokens, topics)
+      for (t <- 0 until 15) {
+        docTopicCounter = computedModel.sampleTokens(docTopicCounter,
+          tokens, topics)
+      }
+      doc.activeIterator.map { case (term, counter) =>
+        val ev = topics.zipWithIndex.filter { case (topic, offset) =>
+          term == tokens(offset)
+        }.map(_._1)
+        Edge(term, newDocId, ev)
+      }.toArray
+    }
+  }
+
+  // scalastyle:off
+  /**
+   * 这里组合使用 Gibbs sampler 和 Metropolis Hastings sampler
+   * 每次采样的复杂度为: O(1)
+   * 使用 Gibbs sampler 采样论文 Rethinking LDA: Why Priors Matter 公式(3)
+   * \frac{{n}_{kw}^{-di}+{\beta }_{w}}{{n}_{k}^{-di}+\bar{\beta}} \frac{{n}_{kd} ^{-di}+ \bar{\alpha} \frac{{n}_{k}^{-di} + \acute{\alpha}}{\sum{n}_{k} +\bar{\acute{\alpha}}}}{\sum{n}_{kd}^{-di} +\bar{\alpha}}
+   * 其中
+   * \bar{\beta}=\sum_{w}{\beta}_{w}
+   * \bar{\alpha}=\sum_{k}{\alpha}_{k}
+   * \bar{\acute{\alpha}}=\bar{\acute{\alpha}}=\sum_{k}\acute{\alpha}
+   * {n}_{kd} 是文档d中主题为k的tokens数
+   * {n}_{kw} 词中主题为k的tokens数
+   * {n}_{k} 是语料库中主题为k的tokens数
+   */
+  // scalastyle:on
+  def tokenSampling(
+    gen: Random,
+    t: Table,
+    tSum: Double,
+    w: Table,
+    wSum: Double,
+    d: Table,
+    dSum: Double): Int = {
+    val distSum = tSum + wSum + dSum
+    val genSum = gen.nextDouble() * distSum
+    if (genSum < dSum) {
+      sampleAlias(gen, d)
+    } else if (genSum < (dSum + wSum)) {
+      sampleAlias(gen, w)
+    } else {
+      sampleAlias(gen, t)
+    }
+  }
+
+
+  private def tDense(
+    totalTopicCounter: BDV[Count],
+    numTokens: Double,
+    numTerms: Double,
+    alpha: Double,
+    alphaAS: Double,
+    beta: Double): (Double, BDV[Double]) = {
+    val numTopics = totalTopicCounter.length
+    val t = BDV.zeros[Double](numTopics)
+    val alphaSum = alpha * numTopics
+    val termSum = numTokens - 1D + alphaAS * numTopics
+    val betaSum = numTerms * beta
+    var sum = 0.0
+    for (topic <- 0 until numTopics) {
+      val last = beta * alphaSum * (totalTopicCounter(topic) + alphaAS) /
+        ((totalTopicCounter(topic) + betaSum) * termSum)
+      t(topic) = last
+      sum += last
+    }
+    (sum, t)
+  }
+
+  private def wSparse(
+    totalTopicCounter: BDV[Count],
+    termTopicCounter: VD,
+    numTokens: Double,
+    numTerms: Double,
+    alpha: Double,
+    alphaAS: Double,
+    beta: Double): (Double, BSV[Double]) = {
+    val numTopics = totalTopicCounter.length
+    val alphaSum = alpha * numTopics
+    val termSum = numTokens - 1D + alphaAS * numTopics
+    val betaSum = numTerms * beta
+    val w = BSV.zeros[Double](numTopics)
+    var sum = 0.0
+    termTopicCounter.activeIterator.foreach { t =>
+      val topic = t._1
+      val count = t._2
+      val last = count * alphaSum * (totalTopicCounter(topic) + alphaAS) /
+        ((totalTopicCounter(topic) + betaSum) * termSum)
+      w(topic) = last
+      sum += last
+    }
+    (sum, w)
+  }
+
+  private def dSparse(
+    totalTopicCounter: BDV[Count],
+    termTopicCounter: VD,
+    docTopicCounter: VD,
+    currentTopic: Int,
+    numTokens: Double,
+    numTerms: Double,
+    alpha: Double,
+    alphaAS: Double,
+    beta: Double): (Double, BSV[Double]) = {
+    val numTopics = totalTopicCounter.length
+    // val termSum = numTokens - 1D + alphaAS * numTopics
+    val betaSum = numTerms * beta
+    val d = BSV.zeros[Double](numTopics)
+    var sum = 0.0
+    docTopicCounter.activeIterator.foreach { t =>
+      val topic = t._1
+      val count = if (currentTopic == topic && t._2 != 1) t._2 - 1 else t._2
+      // val last = count * termSum * (termTopicCounter(topic) + beta) /
+      //  ((totalTopicCounter(topic) + betaSum) * termSum)
+      val last = count * (termTopicCounter(topic) + beta) /
+        (totalTopicCounter(topic) + betaSum)
+      d(topic) = last
+      sum += last
+    }
+    (sum, d)
+  }
+
+  private def wordTable(
+    gen: Random,
+    cacheMap: AppendOnlyMap[VertexId, SoftReference[(Double, Table)]],
+    totalTopicCounter: BDV[Count],
+    termTopicCounter: VD,
+    termId: VertexId,
+    numTokens: Double,
+    numTerms: Double,
+    alpha: Double,
+    alphaAS: Double,
+    beta: Double): (Double, Table) = {
+    var w = cacheMap(termId)
+    if (w == null || w.get() == null || gen.nextDouble() < 1e-5) {
+      termTopicCounter.synchronized {
+        val t = wSparse(totalTopicCounter, termTopicCounter,
+          numTokens, numTerms, alpha, alphaAS, beta)
+        w = new SoftReference((t._1, generateAlias(t._2, t._1)))
+        cacheMap.update(termId, w)
+      }
+    }
+    w.get()
+  }
+
+  private def docTable(
+    totalTopicCounter: BDV[Count],
+    termTopicCounter: VD,
+    docTopicCounter: VD,
+    currentTopic: Int,
+    numTokens: Double,
+    numTerms: Double,
+    alpha: Double,
+    alphaAS: Double,
+    beta: Double): (Double, Table) = {
+    val d = dSparse(totalTopicCounter, termTopicCounter, docTopicCounter,
+      currentTopic, numTokens, numTerms, alpha, alphaAS, beta)
+    (d._1, generateAlias(d._2, d._1))
+  }
+
+}
+
+class LDAKryoRegistrator extends KryoRegistrator {
+  def registerClasses(kryo: com.esotericsoftware.kryo.Kryo) {
+    val gkr = new GraphKryoRegistrator
+    gkr.registerClasses(kryo)
+
+    kryo.register(classOf[BSV[LDA.Count]])
+    kryo.register(classOf[BSV[Double]])
+
+    kryo.register(classOf[BDV[LDA.Count]])
+    kryo.register(classOf[BDV[Double]])
+
+    kryo.register(classOf[SV])
+    kryo.register(classOf[SSV])
+    kryo.register(classOf[SDV])
+
+    kryo.register(classOf[LDA.ED])
+    kryo.register(classOf[LDA.VD])
+
+    kryo.register(classOf[Random])
+    kryo.register(classOf[LDA])
+    kryo.register(classOf[LDAModel])
+  }
+}

--- a/mllib/src/main/scala/org/apache/spark/mllib/clustering/LDA.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/clustering/LDA.scala
@@ -145,7 +145,7 @@ class LDA private[mllib](
 
   def runGibbsSampling(iterations: Int): Unit = {
     for (iter <- 1 to iterations) {
-      println(s"perplexity $iter: ${perplexity()}")
+      // println(s"perplexity $iter: ${perplexity()}")
       logInfo(s"Start Gibbs sampling (Iteration $iter/$iterations)")
       gibbsSampling()
     }

--- a/mllib/src/main/scala/org/apache/spark/mllib/clustering/LDA.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/clustering/LDA.scala
@@ -390,15 +390,14 @@ object LDA {
       if (computedModel != null) model = computedModel.value
       iter.flatMap {
         case (docId, doc) =>
-          initializeEdges(gen, new BSV[Int](doc.indices, doc.values.map(_.toInt), doc.size),
-            docId, numTopics, model)
+          val bsv = new BSV[Int](doc.indices, doc.values.map(_.toInt), doc.size)
+          initializeEdges(gen, bsv, docId, numTopics, model)
       }
     })
     var corpus: Graph[VD, ED] = Graph.fromEdges(edges, null, storageLevel, storageLevel)
-    corpus.partitionBy(PartitionStrategy.EdgePartition1D)
     corpus = updateCounter(corpus, numTopics).cache()
     corpus.vertices.count()
-    corpus
+    corpus.partitionBy(PartitionStrategy.EdgePartition1D)
   }
 
   private def initializeEdges(

--- a/mllib/src/main/scala/org/apache/spark/mllib/clustering/LDA.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/clustering/LDA.scala
@@ -290,6 +290,35 @@ object LDA {
     topicModeling.saveModel(1)
   }
 
+  /**
+   * topicID termID+1:counter termID+1:counter ..
+   */
+  def trainAndSaveModel(
+    docs: RDD[(DocId, SSV)],
+    dir: String,
+    numTopics: Int = 2048,
+    totalIter: Int = 150,
+    alpha: Double = 0.01,
+    beta: Double = 0.01,
+    alphaAS: Double = 0.1): Unit = {
+    import org.apache.spark.mllib.regression.LabeledPoint
+    import org.apache.spark.mllib.util.MLUtils
+    import org.apache.spark.mllib.linalg.Vectors
+    val lda = new LDA(docs, numTopics, alpha, beta, alphaAS)
+    val numTerms = lda.numTerms
+    lda.runGibbsSampling(totalIter)
+    val rdd = lda.termVertices.flatMap { case (termId, counter) =>
+      counter.activeIterator.map { case (topic, cn) =>
+        val sv = BSV.zeros[Double](numTerms)
+        sv(termId.toInt) = cn.toDouble
+        (topic, sv)
+      }
+    }.reduceByKey { (a, b) => a + b}.map { case (topic, sv) =>
+      LabeledPoint(topic.toDouble, Vectors.fromBreeze(sv))
+    }
+    MLUtils.saveAsLibSVMFile(rdd, dir)
+  }
+
   def incrementalTrain(docs: RDD[(DocId, SSV)],
     computedModel: LDAModel,
     alphaAS: Double = 1,
@@ -486,7 +515,7 @@ object LDA {
    * -di 减去当前token的主题
    */
   // scalastyle:on
-  def tokenSampling(
+  private def tokenSampling(
     gen: Random,
     t: Table,
     tSum: Double,

--- a/mllib/src/main/scala/org/apache/spark/mllib/clustering/LDA.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/clustering/LDA.scala
@@ -128,7 +128,7 @@ class LDA private[mllib](
 
     val counterCorpus = updateCounter(sampledCorpus, numTopics)
     counterCorpus.persist(storageLevel)
-    counterCorpus.vertices.count()
+    // counterCorpus.vertices.count()
     counterCorpus.edges.count()
     totalTopicCounter = collectTotalTopicCounter(counterCorpus)
 
@@ -172,7 +172,7 @@ class LDA private[mllib](
 
   def runGibbsSampling(iterations: Int): Unit = {
     for (iter <- 1 to iterations) {
-      // println(s"perplexity $iter: ${perplexity()}")
+      // println(s"perplexity $iter:                 ${perplexity}")
       logInfo(s"Start Gibbs sampling (Iteration $iter/$iterations)")
       gibbsSampling()
     }

--- a/mllib/src/main/scala/org/apache/spark/mllib/clustering/LDAModel.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/clustering/LDAModel.scala
@@ -1,0 +1,393 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.mllib.clustering
+
+import java.lang.ref.SoftReference
+import java.util.Random
+import java.util.{PriorityQueue => JPriorityQueue}
+
+import org.apache.spark.util.random.XORShiftRandom
+
+import scala.reflect.ClassTag
+
+import breeze.linalg.{Vector => BV, DenseVector => BDV, SparseVector => BSV,
+sum => brzSum, norm => brzNorm}
+
+import org.apache.spark.mllib.linalg.{Vectors, DenseVector => SDV, SparseVector => SSV}
+import org.apache.spark.util.collection.AppendOnlyMap
+
+import LDAUtils._
+
+class LDAModel private[mllib](
+  private[mllib] val gtc: BDV[Double],
+  private[mllib] val ttc: Array[BSV[Double]],
+  val alpha: Double,
+  val beta: Double,
+  val alphaAS: Double) extends Serializable {
+
+  def this(topicCounts: SDV, topicTermCounts: Array[SSV], alpha: Double, beta: Double) {
+    this(new BDV[Double](topicCounts.toArray), topicTermCounts.map(t =>
+      new BSV(t.indices, t.values, t.size)), alpha, beta, alpha)
+  }
+
+  @transient private lazy val numTopics = gtc.size
+  @transient private lazy val numTerms = ttc.size
+  @transient private lazy val numTokens = brzSum(gtc)
+  @transient private lazy val betaSum = numTerms * beta
+  @transient private lazy val alphaSum = numTopics * alpha
+  @transient private lazy val termSum = numTokens + alphaAS * numTopics
+
+  @transient private lazy val wordTableCache =
+    new AppendOnlyMap[Int, SoftReference[(Double, Table)]]()
+  @transient private lazy val (t, tSum) = {
+    val dv = tDense(gtc, numTokens, numTerms, alpha, alphaAS, beta)
+    (generateAlias(dv._2, dv._1), dv._1)
+  }
+  @transient private lazy val rand = new XORShiftRandom()
+
+  def setSeed(seed: Long): Unit = {
+    rand.setSeed(seed)
+  }
+
+  def globalTopicCounter = Vectors.fromBreeze(gtc)
+
+  def topicTermCounter = ttc.map(t => Vectors.fromBreeze(t))
+
+  def inference(
+    doc: SSV,
+    totalIter: Int = 10,
+    burnIn: Int = 5): SSV = {
+    require(totalIter > burnIn, "totalIter is less than burnInIter")
+    require(totalIter > 0, "totalIter is less than 0")
+    require(burnIn > 0, "burnInIter is less than 0")
+
+    val topicDist = BSV.zeros[Double](numTopics)
+    val tokens = vector2Array(new BSV[Int](doc.indices, doc.values.map(_.toInt), doc.size))
+    val topics = new Array[Int](tokens.length)
+
+    var docTopicCounter = uniformDistSampler(tokens, topics)
+    for (i <- 0 until totalIter) {
+      docTopicCounter = sampleTokens(docTopicCounter, tokens, topics)
+      if (i + burnIn >= totalIter) topicDist :+= docTopicCounter
+    }
+
+    topicDist.compact()
+    topicDist :/= brzNorm(topicDist, 1)
+    Vectors.fromBreeze(topicDist).asInstanceOf[SSV]
+  }
+
+  private[mllib] def vector2Array(vec: BV[Int]): Array[Int] = {
+    val docLen = brzSum(vec)
+    var offset = 0
+    val sent = new Array[Int](docLen)
+    vec.activeIterator.foreach { case (term, cn) =>
+      for (i <- 0 until cn) {
+        sent(offset) = term
+        offset += 1
+      }
+    }
+    sent
+  }
+
+  private[mllib] def uniformDistSampler(
+    tokens: Array[Int],
+    topics: Array[Int]): BSV[Double] = {
+    val docTopicCounter = BSV.zeros[Double](numTopics)
+    for (i <- 0 until tokens.length) {
+      val topic = uniformSampler(rand, numTopics)
+      topics(i) = topic
+      docTopicCounter(topic) += 1D
+    }
+    docTopicCounter
+  }
+
+  private[mllib] def sampleTokens(
+    docTopicCounter: BSV[Double],
+    tokens: Array[Int],
+    topics: Array[Int]): BSV[Double] = {
+    for (i <- 0 until topics.length) {
+      val termId = tokens(i)
+      val currentTopic = topics(i)
+      val (dSum, d) = docTable(gtc, ttc(termId), docTopicCounter,
+        currentTopic, numTokens, numTerms, alpha, alphaAS, beta)
+
+      val (wSum, w) = wordTable(wordTableCache, gtc, ttc(termId), termId,
+        numTokens, numTerms, alpha, alphaAS, beta)
+      val newTopic = tokenSampling(rand, t, tSum, w, wSum, d, dSum)
+      if (newTopic != currentTopic) {
+        docTopicCounter(newTopic) += 1D
+        docTopicCounter(currentTopic) -= 1D
+        topics(i) = newTopic
+        if (docTopicCounter(currentTopic) == 0) {
+          docTopicCounter.compact()
+        }
+      }
+    }
+    docTopicCounter
+  }
+
+  private def tokenSampling(
+    gen: Random,
+    t: Table,
+    tSum: Double,
+    w: Table,
+    wSum: Double,
+    d: Table,
+    dSum: Double): Int = {
+    val distSum = tSum + wSum + dSum
+    val genSum = gen.nextDouble() * distSum
+    if (genSum < dSum) {
+      sampleAlias(gen, d)
+    } else if (genSum < (dSum + wSum)) {
+      sampleAlias(gen, w)
+    } else {
+      sampleAlias(gen, t)
+    }
+  }
+
+
+  private def tDense(
+    totalTopicCounter: BDV[Double],
+    numTokens: Double,
+    numTerms: Double,
+    alpha: Double,
+    alphaAS: Double,
+    beta: Double): (Double, BDV[Double]) = {
+    val t = BDV.zeros[Double](numTopics)
+    var sum = 0.0
+    for (topic <- 0 until numTopics) {
+      val last = beta * alphaSum * (totalTopicCounter(topic) + alphaAS) /
+        ((totalTopicCounter(topic) + betaSum) * termSum)
+      t(topic) = last
+      sum += last
+    }
+    (sum, t)
+  }
+
+  private def wSparse(
+    totalTopicCounter: BDV[Double],
+    termTopicCounter: BSV[Double],
+    numTokens: Double,
+    numTerms: Double,
+    alpha: Double,
+    alphaAS: Double,
+    beta: Double): (Double, BSV[Double]) = {
+    val w = BSV.zeros[Double](numTopics)
+    var sum = 0.0
+    termTopicCounter.activeIterator.foreach { t =>
+      val topic = t._1
+      val count = t._2
+      val last = count * alphaSum * (totalTopicCounter(topic) + alphaAS) /
+        ((totalTopicCounter(topic) + betaSum) * termSum)
+      w(topic) = last
+      sum += last
+    }
+    (sum, w)
+  }
+
+  private def dSparse(
+    totalTopicCounter: BDV[Double],
+    termTopicCounter: BSV[Double],
+    docTopicCounter: BSV[Double],
+    currentTopic: Int,
+    numTokens: Double,
+    numTerms: Double,
+    alpha: Double,
+    alphaAS: Double,
+    beta: Double): (Double, BSV[Double]) = {
+    val d = BSV.zeros[Double](numTopics)
+    var sum = 0.0
+    docTopicCounter.activeIterator.foreach { t =>
+      val topic = t._1
+      val count = if (currentTopic == topic && t._2 != 1) t._2 - 1 else t._2
+      val last = count * (termTopicCounter(topic) + beta) /
+        (totalTopicCounter(topic) + betaSum)
+      d(topic) = last
+      sum += last
+    }
+    (sum, d)
+  }
+
+  private def wordTable(
+    cacheMap: AppendOnlyMap[Int, SoftReference[(Double, Table)]],
+    totalTopicCounter: BDV[Double],
+    termTopicCounter: BSV[Double],
+    termId: Int,
+    numTokens: Double,
+    numTerms: Double,
+    alpha: Double,
+    alphaAS: Double,
+    beta: Double): (Double, Table) = {
+    var w = cacheMap(termId)
+    if (w == null || w.get() == null) {
+      val t = wSparse(totalTopicCounter, termTopicCounter,
+        numTokens, numTerms, alpha, alphaAS, beta)
+      w = new SoftReference((t._1, generateAlias(t._2, t._1)))
+      cacheMap.update(termId, w)
+
+    }
+    w.get()
+  }
+
+  private def docTable(
+    totalTopicCounter: BDV[Double],
+    termTopicCounter: BSV[Double],
+    docTopicCounter: BSV[Double],
+    currentTopic: Int,
+    numTokens: Double,
+    numTerms: Double,
+    alpha: Double,
+    alphaAS: Double,
+    beta: Double): (Double, Table) = {
+    val d = dSparse(totalTopicCounter, termTopicCounter, docTopicCounter,
+      currentTopic, numTokens, numTerms, alpha, alphaAS, beta)
+    (d._1, generateAlias(d._2, d._1))
+  }
+
+  private[mllib] def mergeOne(term: Int, topic: Int, inc: Int) = {
+    gtc(topic) += inc
+    ttc(term)(topic) += inc
+    this
+  }
+
+  private[mllib] def merge(term: Int, counter: BV[Int]) = {
+    counter.activeIterator.foreach { case (topic, cn) =>
+      mergeOne(term, topic, cn)
+    }
+    this
+  }
+
+  private[mllib] def merge(other: LDAModel) = {
+    gtc :+= other.gtc
+    for (i <- 0 until ttc.length) {
+      ttc(i) :+= other.ttc(i)
+    }
+    this
+  }
+}
+
+object LDAModel {
+  def apply(numTopics: Int, numTerms: Int, alpha: Double = 0.1, beta: Double = 0.01) = {
+    new LDAModel(
+      BDV.zeros[Double](numTopics),
+      (0 until numTerms).map(_ => BSV.zeros[Double](numTopics)).toArray, alpha, beta, alpha)
+  }
+}
+
+private[mllib] object LDAUtils {
+
+  type Table = Array[(Int, Int, Double)]
+
+  @transient private lazy val tableOrdering = new scala.math.Ordering[(Int, Double)] {
+    override def compare(x: (Int, Double), y: (Int, Double)): Int = {
+      Ordering.Double.compare(x._2, y._2)
+    }
+  }
+
+  @transient private lazy val tableReverseOrdering = tableOrdering.reverse
+
+  def generateAlias(sv: BV[Double], sum: Double): Table = {
+    val used = sv.activeSize
+    val probs = sv.activeIterator.slice(0, used)
+    generateAlias(probs, used, sum)
+  }
+
+  def generateAlias(
+    probs: Iterator[(Int, Double)],
+    used: Int,
+    sum: Double): Table = {
+    val pMean = 1.0 / used
+    val table = new Table(used)
+
+    val lq = new JPriorityQueue[(Int, Double)](used, tableOrdering)
+    val hq = new JPriorityQueue[(Int, Double)](used, tableReverseOrdering)
+
+    probs.slice(0, used).foreach { pair =>
+      val i = pair._1
+      val pi = pair._2 / sum
+      if (pi < pMean) {
+        lq.add((i, pi))
+      } else {
+        hq.add((i, pi))
+      }
+    }
+
+    var offset = 0
+    while (!lq.isEmpty & !hq.isEmpty) {
+      val (i, pi) = lq.remove()
+      val (h, ph) = hq.remove()
+      table(offset) = (i, h, pi)
+      val pd = ph - (pMean - pi)
+      if (pd >= pMean) {
+        hq.add((h, pd))
+      } else {
+        lq.add((h, pd))
+      }
+      offset += 1
+    }
+    while (!hq.isEmpty) {
+      val (h, ph) = hq.remove()
+      assert(ph - pMean < 1e-8)
+      table(offset) = (h, h, ph)
+      offset += 1
+    }
+
+    while (!lq.isEmpty) {
+      val (i, pi) = lq.remove()
+      assert(pMean - pi < 1e-8)
+      table(offset) = (i, i, pi)
+      offset += 1
+    }
+
+    // 测试代码 随即抽样一个样本验证其概率
+    //    val (di, dp) = probs(Utils.random.nextInt(used))
+    //    val ds = table.map { t =>
+    //      if (t._1 == di) {
+    //        if (t._2 == t._1) {
+    //          pMean
+    //        } else {
+    //          t._3
+    //        }
+    //      } else if (t._2 == di) {
+    //        pMean - t._3
+    //      } else {
+    //        0.0
+    //      }
+    //    }.sum
+    //    assert((ds - dp).abs < 1e-4)
+
+    table
+  }
+
+  def sampleAlias(gen: Random, table: Table): Int = {
+    val l = table.length
+    val bin = gen.nextInt(l)
+    val i = table(bin)._1
+    val h = table(bin)._2
+    val p = table(bin)._3
+    if (l * p > gen.nextDouble()) {
+      i
+    } else {
+      h
+    }
+  }
+
+  def uniformSampler(rand: Random, dimension: Int): Int = {
+    rand.nextInt(dimension)
+  }
+}

--- a/mllib/src/main/scala/org/apache/spark/mllib/clustering/LDAModel.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/clustering/LDAModel.scala
@@ -243,6 +243,7 @@ class LDAModel private[mllib](
     alpha: Double,
     alphaAS: Double,
     beta: Double): (Double, Table) = {
+    if (termTopicCounter.used == 0) return (0.0, null)
     var w = cacheMap(termId)
     if (w == null || w.get() == null) {
       val t = wSparse(totalTopicCounter, termTopicCounter,

--- a/mllib/src/main/scala/org/apache/spark/mllib/clustering/LDAModel.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/clustering/LDAModel.scala
@@ -21,15 +21,12 @@ import java.lang.ref.SoftReference
 import java.util.Random
 import java.util.{PriorityQueue => JPriorityQueue}
 
-import org.apache.spark.util.random.XORShiftRandom
-
-import scala.reflect.ClassTag
-
 import breeze.linalg.{Vector => BV, DenseVector => BDV, SparseVector => BSV,
 sum => brzSum, norm => brzNorm}
 
 import org.apache.spark.mllib.linalg.{Vectors, DenseVector => SDV, SparseVector => SSV}
 import org.apache.spark.util.collection.AppendOnlyMap
+import org.apache.spark.util.random.XORShiftRandom
 
 import LDAUtils._
 

--- a/mllib/src/test/scala/org/apache/spark/mllib/clustering/LDASuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/clustering/LDASuite.scala
@@ -1,0 +1,149 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.mllib.clustering
+
+import java.util.Random
+
+import org.apache.spark.mllib.util.MLlibTestSparkContext
+import org.scalatest.FunSuite
+
+import breeze.linalg.{DenseVector => BDV, SparseVector => BSV}
+import breeze.stats.distributions.Poisson
+import org.apache.spark.mllib.linalg.{Vectors, SparseVector => SSV}
+ 
+class LDASuite extends FunSuite with MLlibTestSparkContext {
+
+  import LDASuite._
+
+  test("LDA || Gibbs sampling") {
+    val model = generateRandomLDAModel(numTopics, numTerms)
+    val corpus = sampleCorpus(model, numDocs, numTerms, numTopics)
+
+    val data = sc.parallelize(corpus, 2)
+    val pps = new Array[Double](incrementalLearning)
+    val lda = new LDA(data, numTopics, alpha, beta, alphaAS)
+    var i = 0
+    val startedAt = System.currentTimeMillis()
+    while (i < incrementalLearning) {
+      lda.runGibbsSampling(totalIterations)
+      pps(i) = lda.perplexity
+      i += 1
+    }
+
+    println((System.currentTimeMillis() - startedAt) / 1e3)
+    pps.foreach(println)
+
+    val ppsDiff = pps.init.zip(pps.tail).map { case (lhs, rhs) => lhs - rhs}
+    assert(ppsDiff.count(_ > 0).toDouble / ppsDiff.size > 0.6)
+    assert(pps.head - pps.last > 0)
+  }
+
+}
+
+object LDASuite {
+  val numTopics = 5
+  val numTerms = 1000
+  val numDocs = 100
+  val expectedDocLength = 300
+  val alpha = 0.01
+  val alphaAS = 1D
+  val beta = 0.01
+  val totalIterations = 2
+  val burnInIterations = 1
+  val incrementalLearning = 10
+
+  /**
+   * Generate a random LDA model, i.e. the topic-term matrix.
+   */
+  def generateRandomLDAModel(numTopics: Int, numTerms: Int): Array[BDV[Double]] = {
+    val model = new Array[BDV[Double]](numTopics)
+    val width = numTerms * 1.0 / numTopics
+    var topic = 0
+    var i = 0
+    while (topic < numTopics) {
+      val topicCentroid = width * (topic + 1)
+      model(topic) = BDV.zeros[Double](numTerms)
+      i = 0
+      while (i < numTerms) {
+        // treat the term list as a circle, so the distance between the first one and the last one
+        // is 1, not n-1.
+        val distance = Math.abs(topicCentroid - i) % (numTerms / 2)
+        // Possibility is decay along with distance
+        model(topic)(i) = 1.0 / (1 + Math.abs(distance))
+        i += 1
+      }
+      topic += 1
+    }
+    model
+  }
+
+  /**
+   * Sample one document given the topic-term matrix.
+   */
+  def ldaSampler(
+    model: Array[BDV[Double]],
+    topicDist: BDV[Double],
+    numTermsPerDoc: Int): Array[Int] = {
+    val samples = new Array[Int](numTermsPerDoc)
+    val rand = new Random()
+    (0 until numTermsPerDoc).foreach { i =>
+      samples(i) = multinomialDistSampler(
+        rand,
+        model(multinomialDistSampler(rand, topicDist))
+      )
+    }
+    samples
+  }
+
+  /**
+   * Sample corpus (many documents) from a given topic-term matrix.
+   */
+  def sampleCorpus(
+    model: Array[BDV[Double]],
+    numDocs: Int,
+    numTerms: Int,
+    numTopics: Int): Array[(Long, SSV)] = {
+    (0 until numDocs).map { i =>
+      val rand = new Random()
+      val numTermsPerDoc = Poisson.distribution(expectedDocLength).sample()
+      val numTopicsPerDoc = rand.nextInt(numTopics / 2) + 1
+      val topicDist = BDV.zeros[Double](numTopics)
+      (0 until numTopicsPerDoc).foreach { _ =>
+        topicDist(rand.nextInt(numTopics)) += 1
+      }
+      val sv = BSV.zeros[Double](numTerms)
+      ldaSampler(model, topicDist, numTermsPerDoc).foreach { term => sv(term) += 1}
+      (i.toLong, Vectors.fromBreeze(sv).asInstanceOf[SSV])
+    }.toArray
+  }
+
+  /**
+   * A multinomial distribution sampler, using roulette method to sample an Int back.
+   */
+  def multinomialDistSampler(rand: Random, dist: BDV[Double]): Int = {
+    val distSum = rand.nextDouble() * breeze.linalg.sum[BDV[Double], Double](dist)
+
+    def loop(index: Int, accum: Double): Int = {
+      if (index == dist.length) return dist.length - 1
+      val sum = accum - dist(index)
+      if (sum <= 0) index else loop(index + 1, sum)
+    }
+
+    loop(0, distSum)
+  }
+}


### PR DESCRIPTION
In LDA.sampleTokens, there was a table cache for terms (AppendOnlyMap[Vid, SoftReference[Table]]), it's not necessary  in that edges in GraphX are clustered by source ids (term id in this case). A simple table cache does all the magic.
